### PR TITLE
Fix typo for categories in default data for a new post.

### DIFF
--- a/reducers/newPost.js
+++ b/reducers/newPost.js
@@ -13,7 +13,7 @@ const defaultData = {
 		raw: '',
 		rendered: '',
 	},
-	categores: [],
+	categories: [],
 	tags: [],
 	featured_image: 0,
 	date: null,


### PR DESCRIPTION
Fixes the key for the categories in the default data returned by the reducer when creating a new post.