### PR TITLE
Avoid adding duplicate sites.

### DIFF
--- a/actions/addSite.js
+++ b/actions/addSite.js
@@ -7,6 +7,19 @@ import { values, trimEnd } from 'lodash'
 export default function addSite( url, args = {} ) {
 
 	return ( dispatch, getStore ) => {
+		/*
+		 * Don't add duplicate sites.
+		 */
+		var siteUrls = values( getStore().sites ).map( site => site.url );
+
+		if (siteUrls.indexOf( url ) > 0 ) {
+			dispatch({
+				type: 'ADD_SITE_URL_ALREADY_EXISTING'
+			})
+
+			return
+		}
+
 		dispatch({
 			type: 'ADD_SITE_START',
 			url: url,

--- a/reducers/newSite.js
+++ b/reducers/newSite.js
@@ -1,5 +1,7 @@
 export default function newSite( state = { status: null, errorStatus: null }, action ) {
 	switch ( action.type ) {
+		case 'ADD_SITE_URL_ALREADY_EXISTING':
+			return {...state, status: null, errorStatus: 'Site already added.'}
 		case 'ADD_SITE_START':
 			return {...state, status: 'Adding site...', errorStatus: null}
 		case 'ADD_SITE_BROKER_CONNECTING':


### PR DESCRIPTION
Checks whether a site URL already exists in the app before going through the process of adding it.

Fixes #10.