### PR TITLE
Remove blue-dots references to fix compiling

### DIFF
--- a/ios/Vienna.xcodeproj/project.pbxproj
+++ b/ios/Vienna.xcodeproj/project.pbxproj
@@ -29,8 +29,6 @@
 		D835CCB01D195E5C00056B7C /* app-icon-60@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = D835CCAA1D195E5C00056B7C /* app-icon-60@2x.png */; };
 		D835CCB11D195E5C00056B7C /* app-icon-60@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = D835CCAB1D195E5C00056B7C /* app-icon-60@3x.png */; };
 		D837D9451D2E5387008F7566 /* libSafariViewManager.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D837D9441D2E5373008F7566 /* libSafariViewManager.a */; };
-		D842ADC31D198C5500C63467 /* MMTouchDotGestureRecognizer.m in Sources */ = {isa = PBXBuildFile; fileRef = D842ADBF1D198C5500C63467 /* MMTouchDotGestureRecognizer.m */; };
-		D842ADC41D198C5500C63467 /* MMTouchDotView.m in Sources */ = {isa = PBXBuildFile; fileRef = D842ADC21D198C5500C63467 /* MMTouchDotView.m */; };
 		D84ABE651D267E9C00B46A39 /* libRNFetchBlob.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D84ABE631D267D8700B46A39 /* libRNFetchBlob.a */; };
 		D87E51341D19590700F090BA /* app-icon-29.png in Resources */ = {isa = PBXBuildFile; fileRef = D87E51311D19590700F090BA /* app-icon-29.png */; };
 		D87E51351D19590700F090BA /* app-icon-29@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = D87E51321D19590700F090BA /* app-icon-29@2x.png */; };
@@ -660,9 +658,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D842ADC31D198C5500C63467 /* MMTouchDotGestureRecognizer.m in Sources */,
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
-				D842ADC41D198C5500C63467 /* MMTouchDotView.m in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Great concept here! I was trying to run the app, but it would fail because of some references to deleted files.

This fixes it!