### PR TITLE
Use an URI builder to add query parameters during discovery

### DIFF
--- a/actions/addSite.js
+++ b/actions/addSite.js
@@ -4,6 +4,7 @@ import { Linking } from 'react-native';
 import SafariView from 'react-native-safari-view';
 import httpapi from '../api';
 import { values, trimEnd } from 'lodash';
+import URI from 'urijs'
 import fetchSiteData from './fetchSiteData';
 import authorizeSite from './authorizeSite';
 
@@ -33,10 +34,9 @@ export default function addSite(url, args = {}) {
 					throw new Error('Unable to find REST API Link header on the site.');
 				}
 
-				var restUrl = linkHeaders[0].match('<(.+)>; rel="https://api.w.org/"')[
-					1
-				];
-				return fetch(`${restUrl}?context=help`)
+				var restUrl = new URI(linkHeaders[0].match('<(.+)>; rel="https://api.w.org/"')[1]);
+				restUrl.addQuery('context', 'help')
+				return fetch(`${restUrl}`)
 					.then(response => response.json())
 					.then(data => {
 						if (data.namespaces.indexOf('wp/v2') === -1) {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "redux-thunk": "^2.0.1",
     "superagent": "^3.5.2",
     "time-ago": "^0.1.0",
+    "urijs": "^1.18.10",
     "wordpress-rest-api-oauth-1": "^1.1.7"
   },
   "devDependencies": {


### PR DESCRIPTION
This fixes an issue for sites with a rest url including query parameters like:

```xml
<link rel='https://api.w.org/' href='https://bia.is/wp2/?rest_route=/' />
```

* Before the patch, the discovery URL was: `https://bia.is/wp2/?rest_route=/?context=help` 💥 
* After the patch, it's `https://bia.is/wp2/?rest_route=/&context=help` ✅ 