### PR TITLE
Handle errors in list views

### DIFF
--- a/actions/fetchComments.js
+++ b/actions/fetchComments.js
@@ -11,16 +11,20 @@ export default function fetchComments(args) {
 		const site = store.sites[store.activeSite.id];
 		const api = new httpapi(site);
 
-		api.get('/wp/v2/comments', args).then(function(data, err) {
-			if (err) {
-				return;
-			}
+		api.get('/wp/v2/comments', args).then(function(data) {
 			dispatch({
 				type: 'COMMENTS_UPDATED',
 				payload: {
 					comments: data,
 				},
 			});
+		}).catch( error => {
+			dispatch( {
+				type: 'COMMENTS_COMMENT_UPDATE_ERRORED',
+				payload: {
+					error,
+				}
+			})
 		});
 	};
 }

--- a/actions/fetchTerms.js
+++ b/actions/fetchTerms.js
@@ -15,15 +15,20 @@ export default function fetchTerms(args) {
 		const api = new httpapi(site);
 
 		var url = site.data.taxonomies[args.taxonomy]._links['wp:items'][0].href;
-		api.get(url, args).then(function(data, err) {
-			if (err) {
-				return;
-			}
+		api.get(url, args).then(function(data) {
 			dispatch({
 				type: 'TAXONOMY_TERMS_UPDATED',
 				payload: {
 					taxonomy: args.taxonomy,
 					terms: data,
+				},
+			});
+		}).catch( error => {
+			dispatch({
+				type: 'TAXONOMY_TERM_UPDATE_ERRORED',
+				payload: {
+					error,
+					taxonomy: args.taxonomy,
 				},
 			});
 		});

--- a/actions/fetchUsers.js
+++ b/actions/fetchUsers.js
@@ -10,19 +10,18 @@ export default function fetchUsers(args) {
 		dispatch({
 			type: 'USERS_UPDATING',
 		});
-		api.get('/wp/v2/users', args).then(function(data, err) {
-			if (err) {
-				return dispatch({
-					type: 'USERS_UPDATE_ERRORED',
-					payload: {
-						error: err,
-					},
-				});
-			}
+		api.get('/wp/v2/users', args).then(function(data) {
 			dispatch({
 				type: 'USERS_UPDATED',
 				data: data,
 			});
-		});
+		}).catch( err => {
+			return dispatch({
+				type: 'USERS_UPDATE_ERRORED',
+				payload: {
+					error: err,
+				},
+			});
+		})
 	};
 }

--- a/components/General/ListError.js
+++ b/components/General/ListError.js
@@ -10,7 +10,6 @@ const styles = StyleSheet.create({
 	text: {
 		lineHeight: 16,
 		color: 'white',
-		flex: 1,
 		textAlign: 'center',
 	},
 });

--- a/reducers/comments.js
+++ b/reducers/comments.js
@@ -23,6 +23,7 @@ export default function comments( state = defaultState, action ) {
 			}
 		case 'COMMENTS_UPDATING':
 			state.list.loading = true
+			state.list.lastError = null;
 			return {...state}
 		case 'COMMENTS_UPDATED':
 			action.payload.comments.forEach( comment => {
@@ -51,6 +52,7 @@ export default function comments( state = defaultState, action ) {
 			return {...state}
 		case 'COMMENTS_COMMENT_UPDATE_ERRORED':
 			state.list.lastError = action.payload.error
+			state.list.loading = false;
 			return {...state}
 		default:
 			return state;

--- a/reducers/taxonomies.js
+++ b/reducers/taxonomies.js
@@ -15,6 +15,7 @@ export default function types( state = {}, action ) {
 			return action.data
 		case 'TAXONOMY_TERMS_UPDATING':
 			state[ action.payload.taxonomy ].list.loading = true
+			state[ action.payload.taxonomy ].list.lastError = null;
 			return {...state}
 		case 'TAXONOMY_TERMS_UPDATED':
 			forEach( action.payload.terms, term => {
@@ -28,7 +29,8 @@ export default function types( state = {}, action ) {
 			return {...state}
 		case 'TAXONOMY_TERM_CREATE_ERRORED':
 		case 'TAXONOMY_TERM_UPDATE_ERRORED':
-			state[ action.payload.object.taxonomy ].list.lastError = action.payload.error
+			state[ action.payload.taxonomy ].list.lastError = action.payload.error
+			state[ action.payload.taxonomy ].list.loading = false;
 			return {...state}
 		default:
 			return state;

--- a/reducers/users.js
+++ b/reducers/users.js
@@ -16,7 +16,8 @@ export default function users( state = defaultState, action ) {
 				schema: action.payload.site.routes['/wp/v2/users'].schema
 			}
 		case 'USERS_UPDATING':
-			state.list.loading = true
+			state.list.loading = true;
+			state.list.lastError = null;
 			return {...state}
 		case 'USERS_UPDATED':
 			action.data.forEach( user => {
@@ -29,6 +30,7 @@ export default function users( state = defaultState, action ) {
 			return {...state}
 		case 'USERS_UPDATE_ERRORED':
 			state.list.lastError = action.payload.error
+			state.list.loading = false;
 			return {...state}
 		default:
 			return state


### PR DESCRIPTION
When we switched to promises from callbacks, the errors were never handled.