### PR TITLE
Upgrade to React Navigation 5 beta

### DIFF
--- a/Routes.js
+++ b/Routes.js
@@ -20,18 +20,6 @@ import SitesView from './containers/Sites/View';
 import SettingsList from './containers/Settings/List';
 import CommentsEdit from './containers/Comments/Edit';
 
-// const screenOptions = {
-// 	headerStyle: {
-// 		backgroundColor: 'white',
-// 		borderBottomWidth: 0,
-// 		shadowColor: 'transparent',
-// 		shadowRadius: 0,
-// 		shadowOffset: {
-// 			height: 0,
-// 		},
-// 	},
-// };
-
 const defaultOptions = {
 	cardStyle: {
 		backgroundColor: 'white',
@@ -48,137 +36,137 @@ const defaultOptions = {
 	headerStyleInterpolator: HeaderStyleInterpolators.forUIKit,
 };
 
-const MainStack = createStackNavigator();
+const Main = createStackNavigator();
+const Root = createStackNavigator();
 
-const RootStack = () => {
+const MainStack = () => {
 	return (
-		<NavigationNativeContainer>
-			<MainStack.Navigator
-				initialRouteName="SitesList"
-				screenOptions={ defaultOptions }
-			>
-				<MainStack.Screen
-					name="SitesList"
-					component={ SitesList }
-					options={ {
-						title: 'Sites',
-					} }
-				/>
-				<MainStack.Screen
-					name="SitesView"
-					component={ SitesView }
-					options={ ( { route } ) => ( {
-						title: route.params ? route.params.site.name : '',
-					} ) }
-				/>
-				<MainStack.Screen
-					name="SitesReauth"
-					component={ SitesReauth }
-				/>
-				<MainStack.Screen
-					name="PostsList"
-					component={ PostsList }
-					options={ ( { route } ) => ( {
-						title: route.params ? route.params.type.name : '',
-					} ) }
-				/>
-				<MainStack.Screen
-					name="PostsEdit"
-					component={ PostsEdit }
-					options={ ( { route } ) => ( {
-						title: route.params ? `Edit ${ route.params.type.labels.singular_name }` : '',
-					} ) }
-				/>
-				<MainStack.Screen
-					name="PostsAdd"
-					component={ PostsAdd }
-				/>
-				<MainStack.Screen
-					name="TermsEdit"
-					component={ TermsEdit }
-					options={ ( { route } ) => ( {
-						title: route.params ? `Edit ${ route.params.taxonomy.labels.singular_name }` : '',
-					} ) }
-				/>
-				<MainStack.Screen
-					name="TermsAdd"
-					component={ TermsAdd }
-				/>
-				<MainStack.Screen
-					name="TermsList"
-					component={ TermsList }
-					options={ ( { route } ) => ( {
-						title: route.params ? route.params.taxonomy.name : '',
-					} ) }
-				/>
-				<MainStack.Screen
-					name="UsersList"
-					component={ UsersList }
-					options={ {
-						title: 'Users',
-					} }
-				/>
-				<MainStack.Screen
-					name="UsersAdd"
-					component={ UsersAdd }
-				/>
-				<MainStack.Screen
-					name="UsersEdit"
-					component={ UsersEdit }
-				/>
-				<MainStack.Screen
-					name="UsersSelect"
-					component={ UsersSelect }
-				/>
-				<MainStack.Screen
-					name="CommentsList"
-					component={ CommentsList }
-					options={ {
-						title: 'Comments',
-					} }
-				/>
-				<MainStack.Screen
-					name="CommentsEdit"
-					component={ CommentsEdit }
-					options={ {
-						title: 'Edit Comment',
-					} }
-				/>
-				<MainStack.Screen
-					name="SettingsList"
-					component={ SettingsList }
-					options={ {
-						title: 'Settings',
-					} }
-				/>
-			</MainStack.Navigator>
-		</NavigationNativeContainer>
+		<Main.Navigator
+			initialRouteName="SitesList"
+			screenOptions={ defaultOptions }
+		>
+			<Main.Screen
+				name="SitesList"
+				component={ SitesList }
+				options={ {
+					title: 'Sites',
+				} }
+			/>
+			<Main.Screen
+				name="SitesView"
+				component={ SitesView }
+				options={ ( { route } ) => ( {
+					title: route.params ? route.params.site.name : '',
+				} ) }
+			/>
+			<Main.Screen
+				name="SitesReauth"
+				component={ SitesReauth }
+			/>
+			<Main.Screen
+				name="PostsList"
+				component={ PostsList }
+				options={ ( { route } ) => ( {
+					title: route.params ? route.params.type.name : '',
+				} ) }
+			/>
+			<Main.Screen
+				name="PostsEdit"
+				component={ PostsEdit }
+				options={ ( { route } ) => ( {
+					title: route.params ? `Edit ${ route.params.type.labels.singular_name }` : '',
+				} ) }
+			/>
+			<Main.Screen
+				name="PostsAdd"
+				component={ PostsAdd }
+			/>
+			<Main.Screen
+				name="TermsEdit"
+				component={ TermsEdit }
+				options={ ( { route } ) => ( {
+					title: route.params ? `Edit ${ route.params.taxonomy.labels.singular_name }` : '',
+				} ) }
+			/>
+			<Main.Screen
+				name="TermsAdd"
+				component={ TermsAdd }
+			/>
+			<Main.Screen
+				name="TermsList"
+				component={ TermsList }
+				options={ ( { route } ) => ( {
+					title: route.params ? route.params.taxonomy.name : '',
+				} ) }
+			/>
+			<Main.Screen
+				name="UsersList"
+				component={ UsersList }
+				options={ {
+					title: 'Users',
+				} }
+			/>
+			<Main.Screen
+				name="UsersAdd"
+				component={ UsersAdd }
+			/>
+			<Main.Screen
+				name="UsersEdit"
+				component={ UsersEdit }
+			/>
+			<Main.Screen
+				name="UsersSelect"
+				component={ UsersSelect }
+			/>
+			<Main.Screen
+				name="CommentsList"
+				component={ CommentsList }
+				options={ {
+					title: 'Comments',
+				} }
+			/>
+			<Main.Screen
+				name="CommentsEdit"
+				component={ CommentsEdit }
+				options={ {
+					title: 'Edit Comment',
+				} }
+			/>
+			<Main.Screen
+				name="SettingsList"
+				component={ SettingsList }
+				options={ {
+					title: 'Settings',
+				} }
+			/>
+		</Main.Navigator>
 	)
 }
 
-export default RootStack;
-
-// export default createAppContainer(
-// 	createStackNavigator(
-// 		{
-// 			Main: {
-// 				screen: mainStack,
-// 			},
-// 			SitesAdd: {
-// 				screen: SitesAdd,
-// 				navigationOptions: {
-// 					title: 'Add New Site',
-// 				},
-// 			},
-// 		},
-// 		{
-// 			mode: 'modal',
-// 			headerMode: 'none',
-// 			defaultNavigationOptions: {
-// 				...TransitionPresets.ModalPresentationIOS,
-// 				cardOverlayEnabled: true,
-// 				gestureEnabled: true,
-// 			},
-// 		},
-// 	),
-// );
+export default function RootStack() {
+	return (
+		<NavigationNativeContainer>
+			<Root.Navigator
+				headerMode="none"
+				mode="modal"
+				screenOptions={ {
+					...TransitionPresets.ModalPresentationIOS,
+					cardOverlayEnabled: true,
+					gestureEnabled: true,
+				} }
+			>
+				<Root.Screen
+					name="Main"
+					component={ MainStack }
+				/>
+				<Root.Screen
+					name="SitesAdd"
+					component={ SitesAdd }
+					options={ {
+						title: 'Add New Site',
+					} }
+				/>
+			</Root.Navigator>
+		</NavigationNativeContainer>
+	);
+}

--- a/Routes.js
+++ b/Routes.js
@@ -1,5 +1,6 @@
-import { createAppContainer } from 'react-navigation';
-import { createStackNavigator, TransitionPresets, HeaderStyleInterpolators } from 'react-navigation-stack';
+import React from 'react';
+import { NavigationNativeContainer } from '@react-navigation/native';
+import { createStackNavigator, TransitionPresets, HeaderStyleInterpolators } from '@react-navigation/stack';
 
 import SitesList from './containers/Sites/List';
 import SitesAdd from './containers/Sites/Add';
@@ -19,77 +20,165 @@ import SitesView from './containers/Sites/View';
 import SettingsList from './containers/Settings/List';
 import CommentsEdit from './containers/Comments/Edit';
 
-const mainStack = createStackNavigator(
-	{
-		SitesList: { screen: SitesList },
-		SitesView: { screen: SitesView },
-		SitesReauth: { screen: SitesReauth },
-		PostsList: { screen: PostsList },
-		PostsEdit: { screen: PostsEdit },
-		PostsAdd: { screen: PostsAdd },
-		TermsEdit: { screen: TermsEdit },
-		TermsAdd: { screen: TermsAdd },
-		TermsList: { screen: TermsList },
-		UsersList: { screen: UsersList },
-		UsersAdd: { screen: UsersAdd },
-		UsersEdit: { screen: UsersEdit },
-		UsersSelect: { screen: UsersSelect },
-		CommentsList: { screen: CommentsList },
-		CommentsEdit: { screen: CommentsEdit },
-		SettingsList: { screen: SettingsList },
-	},
-	{
-		initialRouteName: 'SitesList',
-		navigationOptions: {
-			headerStyle: {
-				backgroundColor: 'white',
-				borderBottomWidth: 0,
-				shadowColor: 'transparent',
-				shadowRadius: 0,
-				shadowOffset: {
-					height: 0,
-				},
-			},
-		},
-		defaultNavigationOptions: {
-			cardStyle: {
-				backgroundColor: 'white',
-				borderTopWidth: 0,
-				shadowRadius: 0,
-				shadowOffset: {
-					height: 0,
-				},
-				shadowColor: 'transparent',
-			},
-			headerStyle: {
-				shadowOpacity: 0,
-			},
-			headerStyleInterpolator: HeaderStyleInterpolators.forUIKit,
-		},
-	},
-);
+// const screenOptions = {
+// 	headerStyle: {
+// 		backgroundColor: 'white',
+// 		borderBottomWidth: 0,
+// 		shadowColor: 'transparent',
+// 		shadowRadius: 0,
+// 		shadowOffset: {
+// 			height: 0,
+// 		},
+// 	},
+// };
 
-export default createAppContainer(
-	createStackNavigator(
-		{
-			Main: {
-				screen: mainStack,
-			},
-			SitesAdd: {
-				screen: SitesAdd,
-				navigationOptions: {
-					title: 'Add New Site',
-				},
-			},
+const defaultOptions = {
+	cardStyle: {
+		backgroundColor: 'white',
+		borderTopWidth: 0,
+		shadowRadius: 0,
+		shadowOffset: {
+			height: 0,
 		},
-		{
-			mode: 'modal',
-			headerMode: 'none',
-			defaultNavigationOptions: {
-				...TransitionPresets.ModalPresentationIOS,
-				cardOverlayEnabled: true,
-				gestureEnabled: true,
-			},
-		},
-	),
-);
+		shadowColor: 'transparent',
+	},
+	headerStyle: {
+		shadowOpacity: 0,
+	},
+	headerStyleInterpolator: HeaderStyleInterpolators.forUIKit,
+};
+
+const MainStack = createStackNavigator();
+
+const RootStack = () => {
+	return (
+		<NavigationNativeContainer>
+			<MainStack.Navigator
+				initialRouteName="SitesList"
+				screenOptions={ defaultOptions }
+			>
+				<MainStack.Screen
+					name="SitesList"
+					component={ SitesList }
+					options={ {
+						title: 'Sites',
+					} }
+				/>
+				<MainStack.Screen
+					name="SitesView"
+					component={ SitesView }
+					options={ ( { route } ) => ( {
+						title: route.params ? route.params.site.name : '',
+					} ) }
+				/>
+				<MainStack.Screen
+					name="SitesReauth"
+					component={ SitesReauth }
+				/>
+				<MainStack.Screen
+					name="PostsList"
+					component={ PostsList }
+					options={ ( { route } ) => ( {
+						title: route.params ? route.params.type.name : '',
+					} ) }
+				/>
+				<MainStack.Screen
+					name="PostsEdit"
+					component={ PostsEdit }
+					options={ ( { route } ) => ( {
+						title: route.params ? `Edit ${ route.params.type.labels.singular_name }` : '',
+					} ) }
+				/>
+				<MainStack.Screen
+					name="PostsAdd"
+					component={ PostsAdd }
+				/>
+				<MainStack.Screen
+					name="TermsEdit"
+					component={ TermsEdit }
+					options={ ( { route } ) => ( {
+						title: route.params ? `Edit ${ route.params.taxonomy.labels.singular_name }` : '',
+					} ) }
+				/>
+				<MainStack.Screen
+					name="TermsAdd"
+					component={ TermsAdd }
+				/>
+				<MainStack.Screen
+					name="TermsList"
+					component={ TermsList }
+					options={ ( { route } ) => ( {
+						title: route.params ? route.params.taxonomy.name : '',
+					} ) }
+				/>
+				<MainStack.Screen
+					name="UsersList"
+					component={ UsersList }
+					options={ {
+						title: 'Users',
+					} }
+				/>
+				<MainStack.Screen
+					name="UsersAdd"
+					component={ UsersAdd }
+				/>
+				<MainStack.Screen
+					name="UsersEdit"
+					component={ UsersEdit }
+				/>
+				<MainStack.Screen
+					name="UsersSelect"
+					component={ UsersSelect }
+				/>
+				<MainStack.Screen
+					name="CommentsList"
+					component={ CommentsList }
+					options={ {
+						title: 'Comments',
+					} }
+				/>
+				<MainStack.Screen
+					name="CommentsEdit"
+					component={ CommentsEdit }
+					options={ {
+						title: 'Edit Comment',
+					} }
+				/>
+				<MainStack.Screen
+					name="SettingsList"
+					component={ SettingsList }
+					options={ {
+						title: 'Settings',
+					} }
+				/>
+			</MainStack.Navigator>
+		</NavigationNativeContainer>
+	)
+}
+
+export default RootStack;
+
+// export default createAppContainer(
+// 	createStackNavigator(
+// 		{
+// 			Main: {
+// 				screen: mainStack,
+// 			},
+// 			SitesAdd: {
+// 				screen: SitesAdd,
+// 				navigationOptions: {
+// 					title: 'Add New Site',
+// 				},
+// 			},
+// 		},
+// 		{
+// 			mode: 'modal',
+// 			headerMode: 'none',
+// 			defaultNavigationOptions: {
+// 				...TransitionPresets.ModalPresentationIOS,
+// 				cardOverlayEnabled: true,
+// 				gestureEnabled: true,
+// 			},
+// 		},
+// 	),
+// );

--- a/components/Setup/InstallConnect.js
+++ b/components/Setup/InstallConnect.js
@@ -39,15 +39,6 @@ const STATUS = {
 };
 
 export default class Start extends Component {
-	static navigatorButtons = {
-		leftButtons: [
-			{
-				title: 'Back',
-				id: 'close',
-			},
-		],
-	};
-
 	state = {
 		status: STATUS.NONE,
 		error: null,

--- a/components/Setup/Start.js
+++ b/components/Setup/Start.js
@@ -43,15 +43,6 @@ const STATUS = {
 };
 
 export default class Start extends Component {
-	static navigatorButtons = {
-		leftButtons: [
-			{
-				title: 'Back',
-				id: 'close',
-			},
-		],
-	};
-
 	state = {
 		url: 'https://',
 		status: STATUS.NONE,

--- a/containers/Comments/Edit.js
+++ b/containers/Comments/Edit.js
@@ -16,15 +16,6 @@ const styles = StyleSheet.create( {
 } );
 
 class Edit extends Component {
-	static navigationOptions = ( { navigationOptions, navigation } ) => ( {
-		headerRight: () => (
-			<NavigationButton
-				onPress={ route.params.onSave || null }
-			>
-				Save
-			</NavigationButton>
-		),
-	} );
 	constructor( props ) {
 		super( props );
 		this.state = {
@@ -33,14 +24,14 @@ class Edit extends Component {
 	}
 
 	componentDidMount() {
-		this.props.navigation.setParams( {
-			onSave: this.onSave,
-		} );
-	}
-
-	componentWillUnmount() {
-		this.props.navigation.setParams( {
-			onSave: null,
+		this.props.navigation.setOptions( {
+			headerRight: () => (
+				<NavigationButton
+					onPress={ this.onSave }
+				>
+					Save
+				</NavigationButton>
+			),
 		} );
 	}
 

--- a/containers/Comments/Edit.js
+++ b/containers/Comments/Edit.js
@@ -17,10 +17,9 @@ const styles = StyleSheet.create( {
 
 class Edit extends Component {
 	static navigationOptions = ( { navigationOptions, navigation } ) => ( {
-		title: 'Edit Comment',
 		headerRight: () => (
 			<NavigationButton
-				onPress={ navigation.state.params.onSave || null }
+				onPress={ route.params.onSave || null }
 			>
 				Save
 			</NavigationButton>
@@ -29,7 +28,7 @@ class Edit extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			comment: { ...this.props.navigation.state.params.comment },
+			comment: { ...this.props.route.params.comment },
 		};
 	}
 

--- a/containers/Comments/List.js
+++ b/containers/Comments/List.js
@@ -16,9 +16,6 @@ const styles = StyleSheet.create( {
 } );
 
 class List extends Component {
-	static navigationOptions = ( { navigationOptions, navigation } ) => ( {
-		title: 'Comments',
-	} );
 	componentDidMount() {
 		if ( isEmpty( this.props.comments.comments ) ) {
 			this.props.dispatch( fetchComments() );

--- a/containers/Posts/Add.js
+++ b/containers/Posts/Add.js
@@ -33,13 +33,13 @@ class Add extends Component {
 
 	onSave = () => {
 		this.props.dispatch(
-			createPost( this.state.post, this.props.navigation.state.params.type.slug ),
+			createPost( this.state.post, this.props.route.params.type.slug ),
 		);
 		this.props.navigation.goBack();
 	}
 
 	render() {
-		const type = this.props.navigation.state.params.type;
+		const type = this.props.route.params.type;
 		const slug = type._links['wp:items'][0].href.split( '/' ).slice( -1 )[0];
 		let schema = this.props.sites[this.props.activeSite.id].routes[
 			'/wp/v2/' + slug

--- a/containers/Posts/Add.js
+++ b/containers/Posts/Add.js
@@ -5,17 +5,6 @@ import Form from '../../components/Posts/Form';
 import NavigationButton from '../../components/Navigation/Button';
 
 class Add extends Component {
-	static navigationOptions = ( { navigationOptions, navigation } ) => ( {
-		title: `Add ${navigation.state.params.type.labels.singular_name}`,
-		headerRight: () => (
-			<NavigationButton
-				onPress={ navigation.state.params.onSave || null }
-			>
-				Save
-			</NavigationButton>
-		),
-	} );
-
 	constructor( props ) {
 		super( props );
 		this.state = {
@@ -24,14 +13,15 @@ class Add extends Component {
 	}
 
 	componentDidMount() {
-		this.props.navigation.setParams( {
-			onSave: this.onSave,
-		} );
-	}
-
-	componentWillUnmount() {
-		this.props.navigation.setParams( {
-			onSave: null,
+		this.props.navigation.setOptions( {
+			title: `Add ${ this.props.route.params.type.labels.singular_name}`,
+			headerRight: () => (
+				<NavigationButton
+					onPress={ this.onSave }
+				>
+					Save
+				</NavigationButton>
+			),
 		} );
 	}
 

--- a/containers/Posts/Edit.js
+++ b/containers/Posts/Edit.js
@@ -6,7 +6,6 @@ import NavigationButton from '../../components/Navigation/Button';
 
 class Edit extends Component {
 	static navigationOptions = ( { navigationOptions, navigation } ) => ( {
-		title: `Edit ${navigation.state.params.type.labels.singular_name}`,
 		headerRight: () => (
 			<NavigationButton
 				onPress={ navigation.state.params.onSave || null }
@@ -19,7 +18,7 @@ class Edit extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			post: { ...props.navigation.state.params.post },
+			post: { ...props.route.params.post },
 		};
 	}
 
@@ -51,7 +50,11 @@ class Edit extends Component {
 	}
 
 	render() {
-		const type = this.props.navigation.state.params.type;
+		if ( ! this.props.route.params ) {
+			return null;
+		}
+
+		const type = this.props.route.params.type;
 		const slug = type._links['wp:items'][0].href.split( '/' ).slice( -1 )[0];
 		let schema = this.props.sites[this.props.activeSite.id].routes[
 			'/wp/v2/' + slug

--- a/containers/Posts/Edit.js
+++ b/containers/Posts/Edit.js
@@ -5,16 +5,6 @@ import { connect } from 'react-redux';
 import NavigationButton from '../../components/Navigation/Button';
 
 class Edit extends Component {
-	static navigationOptions = ( { navigationOptions, navigation } ) => ( {
-		headerRight: () => (
-			<NavigationButton
-				onPress={ navigation.state.params.onSave || null }
-			>
-				Save
-			</NavigationButton>
-		),
-	} );
-
 	constructor( props ) {
 		super( props );
 		this.state = {
@@ -23,14 +13,14 @@ class Edit extends Component {
 	}
 
 	componentDidMount() {
-		this.props.navigation.setParams( {
-			onSave: this.onSave,
-		} );
-	}
-
-	componentWillUnmount() {
-		this.props.navigation.setParams( {
-			onSave: null,
+		this.props.navigation.setOptions( {
+			headerRight: () => (
+				<NavigationButton
+					onPress={ this.onSave }
+				>
+					Save
+				</NavigationButton>
+			),
 		} );
 	}
 

--- a/containers/Posts/List.js
+++ b/containers/Posts/List.js
@@ -32,7 +32,6 @@ const styles = StyleSheet.create( {
 
 class List extends Component {
 	static navigationOptions = ( { navigationOptions, navigation } ) => ( {
-		title: navigation.state.params.type.name,
 		headerRight: () => (
 			<NavigationButton
 				onPress={ () => {
@@ -47,24 +46,24 @@ class List extends Component {
 	} );
 	componentDidMount() {
 		setTimeout( () => {
-			let posts = this.props.types[this.props.navigation.state.params.type.slug]
+			let posts = this.props.types[this.props.route.params.type.slug]
 				.posts;
 			if ( isEmpty( posts ) ) {
 				this.props.dispatch(
-					fetchPosts( { type: this.props.navigation.state.params.type.slug } ),
+					fetchPosts( { type: this.props.route.params.type.slug } ),
 				);
 			}
 		}, 400 );
 	}
 	onRefresh() {
 		this.props.dispatch(
-			fetchPosts( { type: this.props.navigation.state.params.type.slug } ),
+			fetchPosts( { type: this.props.route.params.type.slug } ),
 		);
 	}
 	onSelectPost( post ) {
 		this.props.navigation.navigate( 'PostsEdit', {
 			post: post,
-			type: this.props.navigation.state.params.type,
+			type: this.props.route.params.type,
 		} );
 	}
 	onViewPost( post ) {
@@ -74,11 +73,11 @@ class List extends Component {
 		} );
 	}
 	onChangeFilter( filter ) {
-		this.props.dispatch( updatePostfilter( this.props.navigation.state.params.type.slug, filter ) );
+		this.props.dispatch( updatePostfilter( this.props.route.params.type.slug, filter ) );
 	}
 
 	filterPosts( post ) {
-		let type = this.props.types[this.props.navigation.state.params.type.slug];
+		let type = this.props.types[this.props.route.params.type.slug];
 		if ( type.list.filter.status === 'all' ) {
 			return true;
 		}
@@ -87,7 +86,7 @@ class List extends Component {
 	}
 
 	render() {
-		let type = this.props.navigation.state.params.type;
+		let type = this.props.route.params.type;
 		let posts = type.posts;
 
 		const componentMap = {
@@ -95,9 +94,9 @@ class List extends Component {
 		};
 
 		let ListComponent = componentMap[
-			this.props.navigation.state.params.type.slug
+			this.props.route.params.type.slug
 		]
-			? componentMap[this.props.navigation.state.params.type.slug]
+			? componentMap[this.props.route.params.type.slug]
 			: PostsList;
 
 		return (

--- a/containers/Posts/List.js
+++ b/containers/Posts/List.js
@@ -31,20 +31,21 @@ const styles = StyleSheet.create( {
 } );
 
 class List extends Component {
-	static navigationOptions = ( { navigationOptions, navigation } ) => ( {
-		headerRight: () => (
-			<NavigationButton
-				onPress={ () => {
-					navigation.navigate( 'PostsAdd', {
-						type: navigation.state.params.type,
-					} );
-				} }
-			>
-				Add New
-			</NavigationButton>
-		),
-	} );
 	componentDidMount() {
+		this.props.navigation.setOptions( {
+			headerRight: () => (
+				<NavigationButton
+					onPress={ () => {
+						this.props.navigation.navigate( 'PostsAdd', {
+							type: this.props.route.params.type,
+						} );
+					} }
+				>
+					Add New
+				</NavigationButton>
+			),
+		} );
+
 		setTimeout( () => {
 			let posts = this.props.types[this.props.route.params.type.slug]
 				.posts;
@@ -55,6 +56,7 @@ class List extends Component {
 			}
 		}, 400 );
 	}
+
 	onRefresh() {
 		this.props.dispatch(
 			fetchPosts( { type: this.props.route.params.type.slug } ),

--- a/containers/Settings/List.js
+++ b/containers/Settings/List.js
@@ -13,9 +13,6 @@ const styles = StyleSheet.create( {
 } );
 
 class List extends Component {
-	static navigationOptions = ( { navigationOptions, navigation } ) => ( {
-		title: 'Settings',
-	} );
 	componentDidMount() {
 		if ( isEmpty( this.props.settings.settings ) ) {
 			this.props.dispatch( fetchSettings() );

--- a/containers/Sites/Add.js
+++ b/containers/Sites/Add.js
@@ -1,4 +1,3 @@
-import Constants from 'expo-constants';
 import React, { Component } from 'react';
 import {
 	KeyboardAvoidingView,
@@ -7,7 +6,7 @@ import {
 	TouchableOpacity,
 	View,
 } from 'react-native';
-import { Header, HeaderTitle } from 'react-navigation-stack';
+import { HeaderTitle } from '@react-navigation/stack';
 import { connect } from 'react-redux';
 
 import addSite from '../../actions/addSite';
@@ -105,7 +104,6 @@ class Add extends Component {
 		return (
 			<KeyboardAvoidingView
 				behavior="height"
-				keyboardVerticalOffset={ Header.HEIGHT + Constants.statusBarHeight - 20 }
 				style={ styles.container }
 			>
 				<View style={ styles.header }>

--- a/containers/Sites/List.js
+++ b/containers/Sites/List.js
@@ -7,11 +7,6 @@ import NavigationButton from '../../components/Navigation/Button';
 class List extends Component {
 	static navigationOptions = ( { navigationOptions, navigation } ) => ( {
 		title: 'Sites',
-		headerRight: () => (
-			<NavigationButton onPress={ () => navigation.navigate( 'SitesAdd' ) }>
-				Add Site
-			</NavigationButton>
-		),
 	} );
 	constructor( props ) {
 		super( props );
@@ -21,6 +16,14 @@ class List extends Component {
 	}
 
 	componentDidMount() {
+		this.props.navigation.setOptions( {
+			headerRight: () => (
+				<NavigationButton onPress={ () => this.props.navigation.navigate( 'SitesAdd' ) }>
+					Add Site
+				</NavigationButton>
+			),
+		} );
+
 		this.redirectIfNoSites();
 	}
 

--- a/containers/Sites/View.js
+++ b/containers/Sites/View.js
@@ -65,9 +65,6 @@ const styles = StyleSheet.create( {
 } );
 
 class _View extends Component {
-	static navigationOptions = ( { navigationOptions, navigation } ) => ( {
-		title: navigation.state.params.site.name,
-	} );
 	componentDidMount() {
 		if (
 			isEmpty( this.props.types ) &&

--- a/containers/Terms/Add.js
+++ b/containers/Terms/Add.js
@@ -35,14 +35,14 @@ class Add extends Component {
 		this.props.dispatch(
 			createTerm(
 				this.state.term,
-				this.props.navigation.state.params.taxonomy.slug,
+				this.props.route.params.taxonomy.slug,
 			),
 		);
 		this.props.navigation.goBack();
 	}
 
 	render() {
-		const taxonomy = this.props.navigation.state.params.taxonomy;
+		const taxonomy = this.props.route.params.taxonomy;
 		const slug = taxonomy._links['wp:items'][0].href.split( '/' ).slice( -1 )[0];
 		let schema = this.props.sites[this.props.activeSite.id].routes[
 			'/wp/v2/' + slug

--- a/containers/Terms/Add.js
+++ b/containers/Terms/Add.js
@@ -5,17 +5,6 @@ import { connect } from 'react-redux';
 import NavigationButton from '../../components/Navigation/Button';
 
 class Add extends Component {
-	static navigationOptions = ( { navigationOptions, navigation } ) => ( {
-		title: `Add ${navigation.state.params.taxonomy.labels.singular_name}`,
-		headerRight: () => (
-			<NavigationButton
-				onPress={ navigation.state.params.onSave || null }
-			>
-				Save
-			</NavigationButton>
-		),
-	} );
-
 	constructor( props ) {
 		super( props );
 		this.state = {
@@ -24,14 +13,15 @@ class Add extends Component {
 	}
 
 	componentDidMount() {
-		this.props.navigation.setParams( {
-			onSave: this.onSave,
-		} );
-	}
-
-	componentWillUnmount() {
-		this.props.navigation.setParams( {
-			onSave: null,
+		this.props.navigation.setOptions( {
+			title: `Add ${ this.props.route.params.taxonomy.labels.singular_name }`,
+			headerRight: () => (
+				<NavigationButton
+					onPress={ this.onSave }
+				>
+					Save
+				</NavigationButton>
+			),
 		} );
 	}
 

--- a/containers/Terms/Edit.js
+++ b/containers/Terms/Edit.js
@@ -5,16 +5,6 @@ import { connect } from 'react-redux';
 import NavigationButton from '../../components/Navigation/Button';
 
 class Edit extends Component {
-	static navigationOptions = ( { navigationOptions, navigation } ) => ( {
-		headerRight: () => (
-			<NavigationButton
-				onPress={ navigation.state.params.onSave || null }
-			>
-				Save
-			</NavigationButton>
-		),
-	} );
-
 	constructor( props ) {
 		super( props );
 		this.state = {
@@ -23,19 +13,15 @@ class Edit extends Component {
 	}
 
 	componentDidMount() {
-		this.props.navigation.setParams( {
-			onSave: this.onSave,
+		this.props.navigation.setOptions( {
+			headerRight: () => (
+				<NavigationButton
+					onPress={ this.onSave }
+				>
+					Save
+				</NavigationButton>
+			),
 		} );
-	}
-
-	componentWillUnmount() {
-		this.props.navigation.setParams( {
-			onSave: null,
-		} );
-	}
-
-	onNavigatorEvent() {
-		this.onSave();
 	}
 
 	onChangePropertyValue( property, value ) {

--- a/containers/Terms/Edit.js
+++ b/containers/Terms/Edit.js
@@ -6,7 +6,6 @@ import NavigationButton from '../../components/Navigation/Button';
 
 class Edit extends Component {
 	static navigationOptions = ( { navigationOptions, navigation } ) => ( {
-		title: `Edit ${navigation.state.params.taxonomy.labels.singular_name}`,
 		headerRight: () => (
 			<NavigationButton
 				onPress={ navigation.state.params.onSave || null }
@@ -19,7 +18,7 @@ class Edit extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			term: { ...this.props.navigation.state.params.term },
+			term: { ...this.props.route.params.term },
 		};
 	}
 
@@ -51,7 +50,7 @@ class Edit extends Component {
 	}
 
 	render() {
-		const taxonomy = this.props.navigation.state.params.taxonomy;
+		const taxonomy = this.props.route.params.taxonomy;
 		const slug = taxonomy._links['wp:items'][0].href.split( '/' ).slice( -1 )[0];
 		let schema = this.props.sites[this.props.activeSite.id].routes[
 			'/wp/v2/' + slug

--- a/containers/Terms/List.js
+++ b/containers/Terms/List.js
@@ -8,20 +8,21 @@ import ListError from '../../components/General/ListError';
 import NavigationButton from '../../components/Navigation/Button';
 
 class List extends Component {
-	static navigationOptions = ( { navigationOptions, navigation } ) => ( {
-		headerRight: () => (
-			<NavigationButton
-				onPress={ () => {
-					navigation.navigate( 'TermsAdd', {
-						taxonomy: navigation.state.params.taxonomy,
-					} );
-				} }
-			>
-				Add New
-			</NavigationButton>
-		),
-	} );
 	componentDidMount() {
+		this.props.navigation.setOptions( {
+			headerRight: () => (
+				<NavigationButton
+					onPress={ () => {
+						this.props.navigation.navigate( 'TermsAdd', {
+							taxonomy: this.props.route.params.taxonomy,
+						} );
+					} }
+				>
+					Add New
+				</NavigationButton>
+			),
+		} );
+
 		if ( isEmpty( this.props.route.params.taxonomy.terms ) ) {
 			this.props.dispatch(
 				fetchTerms( {

--- a/containers/Terms/List.js
+++ b/containers/Terms/List.js
@@ -9,7 +9,6 @@ import NavigationButton from '../../components/Navigation/Button';
 
 class List extends Component {
 	static navigationOptions = ( { navigationOptions, navigation } ) => ( {
-		title: navigation.state.params.taxonomy.name,
 		headerRight: () => (
 			<NavigationButton
 				onPress={ () => {
@@ -23,27 +22,27 @@ class List extends Component {
 		),
 	} );
 	componentDidMount() {
-		if ( isEmpty( this.props.navigation.state.params.taxonomy.terms ) ) {
+		if ( isEmpty( this.props.route.params.taxonomy.terms ) ) {
 			this.props.dispatch(
 				fetchTerms( {
-					taxonomy: this.props.navigation.state.params.taxonomy.slug,
+					taxonomy: this.props.route.params.taxonomy.slug,
 				} ),
 			);
 		}
 	}
 	onSelectTerm( term ) {
 		this.props.navigation.navigate( 'TermsEdit', {
-			taxonomy: this.props.navigation.state.params.taxonomy,
+			taxonomy: this.props.route.params.taxonomy,
 			term,
 		} );
 	}
 	onRefresh() {
 		this.props.dispatch(
-			fetchTerms( { taxonomy: this.props.navigation.state.params.taxonomy.slug } ),
+			fetchTerms( { taxonomy: this.props.route.params.taxonomy.slug } ),
 		);
 	}
 	render() {
-		let taxonomy = this.props.navigation.state.params.taxonomy;
+		let taxonomy = this.props.route.params.taxonomy;
 		let terms = taxonomy.terms;
 		return (
 			<ScrollView

--- a/containers/Users/Add.js
+++ b/containers/Users/Add.js
@@ -5,17 +5,6 @@ import Form from '../../components/Users/Form';
 import NavigationButton from '../../components/Navigation/Button';
 
 class Add extends Component {
-	static navigationOptions = ( { navigationOptions, navigation } ) => ( {
-		title: 'Add User',
-		headerRight: () => (
-			<NavigationButton
-				onPress={ navigation.state.params.onSave || null }
-			>
-				Save
-			</NavigationButton>
-		),
-	} );
-
 	constructor( props ) {
 		super( props );
 		this.state = {
@@ -24,14 +13,14 @@ class Add extends Component {
 	}
 
 	componentDidMount() {
-		this.props.navigation.setParams( {
-			onSave: this.onSave,
-		} );
-	}
-
-	componentWillUnmount() {
-		this.props.navigation.setParams( {
-			onSave: null,
+		this.props.navigation.setOptions( {
+			headerRight: () => (
+				<NavigationButton
+					onPress={ this.onSave }
+				>
+					Save
+				</NavigationButton>
+			),
 		} );
 	}
 

--- a/containers/Users/Edit.js
+++ b/containers/Users/Edit.js
@@ -20,17 +20,12 @@ export class Edit extends Component {
 		this.state = {
 			user: users[ props.route.params.user ],
 		};
-		//this.props.navigator.setOnNavigatorEvent(this.onNavigatorEvent.bind(this))
 	}
 
 	componentDidMount() {
 		this.props.navigation.setOptions( {
 			title: this.state.user.name,
 		} );
-	}
-
-	onNavigatorEvent() {
-		this.onSave();
 	}
 
 	onChangePropertyValue( property, value ) {

--- a/containers/Users/Edit.js
+++ b/containers/Users/Edit.js
@@ -1,18 +1,11 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+
 import { updateUser } from '../../actions';
 import Form from '../../components/Users/Form';
+import NavigationButton from '../../components/Navigation/Button';
 
 export class Edit extends Component {
-	static navigatorButtons = {
-		rightButtons: [
-			{
-				title: 'Save',
-				id: 'save',
-			},
-		],
-	};
-
 	constructor( props ) {
 		super( props );
 
@@ -25,6 +18,13 @@ export class Edit extends Component {
 	componentDidMount() {
 		this.props.navigation.setOptions( {
 			title: this.state.user.name,
+			headerRight: () => (
+				<NavigationButton
+					onPress={ this.onSave }
+				>
+					Save
+				</NavigationButton>
+			),
 		} );
 	}
 

--- a/containers/Users/Edit.js
+++ b/containers/Users/Edit.js
@@ -1,8 +1,9 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { updateUser } from '../../actions';
 import Form from '../../components/Users/Form';
 
-export default class Edit extends Component {
+export class Edit extends Component {
 	static navigatorButtons = {
 		rightButtons: [
 			{
@@ -11,29 +12,41 @@ export default class Edit extends Component {
 			},
 		],
 	};
+
 	constructor( props ) {
 		super( props );
+
+		const users = props.site && props.site.data ? props.site.data.users.users : {};
 		this.state = {
-			user: { ...props.users.users[this.props.user] },
+			user: users[ props.route.params.user ],
 		};
 		//this.props.navigator.setOnNavigatorEvent(this.onNavigatorEvent.bind(this))
 	}
+
+	componentDidMount() {
+		this.props.navigation.setOptions( {
+			title: this.state.user.name,
+		} );
+	}
+
 	onNavigatorEvent() {
 		this.onSave();
 	}
+
 	onChangePropertyValue( property, value ) {
 		let user = this.state.user;
 		user[property] = value;
 		this.setState( { user: user } );
 	}
+
 	onSave() {
 		this.props.dispatch( updateUser( this.state.user ) );
-		this.props.navigator.pop();
+		this.props.navigation.pop();
 	}
+
 	render() {
-		let schema = this.props.sites[this.props.activeSite.id].routes[
-			'/wp/v2/users'
-		].schema;
+		const schema = this.props.site.routes['/wp/v2/users'].schema;
+
 		return (
 			<Form
 				user={ this.state.user }
@@ -43,3 +56,9 @@ export default class Edit extends Component {
 		);
 	}
 }
+
+const mapStateToProps = state => ( {
+	site: state.activeSite.id ? state.sites[ state.activeSite.id ] : null,
+} );
+
+export default connect( mapStateToProps )( Edit );

--- a/containers/Users/List.js
+++ b/containers/Users/List.js
@@ -14,7 +14,6 @@ import NavigationButton from '../../components/Navigation/Button';
 
 class List extends Component {
 	static navigationOptions = ( { navigationOptions, navigation } ) => ( {
-		title: 'Users',
 		headerRight: () => (
 			<NavigationButton
 				onPress={ () => {
@@ -37,13 +36,7 @@ class List extends Component {
 		}
 	}
 	onSelectUser( user ) {
-		this.props.navigator.push( {
-			screen: 'UsersEdit',
-			passProps: {
-				user: user.id,
-			},
-			title: user.name,
-		} );
+		this.props.navigation.push( 'UsersEdit', { user: user.id } );
 	}
 	onRefresh() {
 		this.props.dispatch( fetchUsers( { per_page: 100 } ) );

--- a/containers/Users/List.js
+++ b/containers/Users/List.js
@@ -13,28 +13,29 @@ import ListError from '../../components/General/ListError';
 import NavigationButton from '../../components/Navigation/Button';
 
 class List extends Component {
-	static navigationOptions = ( { navigationOptions, navigation } ) => ( {
-		headerRight: () => (
-			<NavigationButton
-				onPress={ () => {
-					navigation.navigate( 'UsersAdd' );
-				} }
-			>
-				Add New
-			</NavigationButton>
-		),
-	} );
 	constructor( props ) {
 		super( props );
 		this.state = {
 			editingUser: null,
 		};
 	}
+
 	componentDidMount() {
+		this.props.navigation.setOptions( {
+			headerRight: () => (
+				<NavigationButton
+					onPress={ () => this.props.navigation.navigate( 'UsersAdd' ) }
+				>
+					Add New
+				</NavigationButton>
+			),
+		} );
+
 		if ( isEmpty( this.props.users.users ) ) {
 			this.props.dispatch( fetchUsers( { per_page: 100 } ) );
 		}
 	}
+
 	onSelectUser( user ) {
 		this.props.navigation.push( 'UsersEdit', { user: user.id } );
 	}

--- a/containers/Users/Select.js
+++ b/containers/Users/Select.js
@@ -21,7 +21,7 @@ export default class List extends Component {
 	}
 	onSelectUser( user ) {
 		this.props.onSelect( user );
-		this.props.navigator.pop();
+		this.props.navigation.pop();
 	}
 	onRefresh() {
 		this.props.dispatch( fetchUsers( { per_page: 100 } ) );

--- a/package.json
+++ b/package.json
@@ -32,8 +32,6 @@
     "react-native-safe-area-context": "0.6.0",
     "react-native-screens": "2.0.0-alpha.12",
     "react-native-webview": "7.4.3",
-    "react-navigation": "^4.0.10",
-    "react-navigation-stack": "^2.0.0-alpha.42",
     "react-redux": "6",
     "react-router-native": "5",
     "redux": "4",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
   "dependencies": {
     "@react-native-community/datetimepicker": "2.1.0",
     "@react-native-community/masked-view": "^0.1.5",
+    "@react-navigation/native": "^5.0.0-alpha.21",
+    "@react-navigation/stack": "^5.0.0-alpha.46",
     "expo": "^36.0.0",
     "expo-localization": "~8.0.0",
     "expo-web-browser": "~8.0.0",

--- a/reducers.js
+++ b/reducers.js
@@ -2,24 +2,11 @@ import { combineReducers } from 'redux';
 import sites from './reducers/sites';
 import activeSite from './reducers/activeSite';
 import newSite from './reducers/newSite';
-import Routes from './Routes';
-
-// const initialState = Routes.router.getStateForAction(
-	// Routes.router.getActionForPathAndParams( 'Main/SitesList' ),
-// );
-const initialState = {};
-const navReducer = ( state = initialState, action ) => {
-	// const nextState = Routes.router.getStateForAction( action, state );
-	const nextState = null;
-	// Simply return the original `state` if `nextState` is null or undefined.
-	return nextState || state;
-};
 
 const allReducers = combineReducers( {
 	sites,
 	activeSite,
 	newSite,
-	navigator: navReducer,
 	loaded: ( state = false, action ) =>
 		action.type === 'REDUX_STORAGE_LOAD' ? true : state,
 } );

--- a/reducers.js
+++ b/reducers.js
@@ -4,11 +4,13 @@ import activeSite from './reducers/activeSite';
 import newSite from './reducers/newSite';
 import Routes from './Routes';
 
-const initialState = Routes.router.getStateForAction(
-	Routes.router.getActionForPathAndParams( 'Main/SitesList' ),
-);
+// const initialState = Routes.router.getStateForAction(
+	// Routes.router.getActionForPathAndParams( 'Main/SitesList' ),
+// );
+const initialState = {};
 const navReducer = ( state = initialState, action ) => {
-	const nextState = Routes.router.getStateForAction( action, state );
+	// const nextState = Routes.router.getStateForAction( action, state );
+	const nextState = null;
 	// Simply return the original `state` if `nextState` is null or undefined.
 	return nextState || state;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1175,6 +1175,16 @@
     query-string "^6.4.2"
     react-is "^16.8.6"
 
+"@react-navigation/core@^5.0.0-alpha.29":
+  version "5.0.0-alpha.29"
+  resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-5.0.0-alpha.29.tgz#547f3468c2c9fab839e72c76d5582c0396006a29"
+  integrity sha512-4lsy04cjFeo08SG/gzgSXXV5tCVqqMC2YfWOoFHKpjTtoxX2hYsVFPrWMwQGB6efXFB4nHxXBGLDfHz67zpN2Q==
+  dependencies:
+    escape-string-regexp "^2.0.0"
+    query-string "^6.9.0"
+    shortid "^2.2.15"
+    use-subscription "^1.3.0"
+
 "@react-navigation/native@^3.6.2":
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-3.6.2.tgz#3634697b6350cc5189657ae4551f2d52b57fbbf0"
@@ -1183,6 +1193,29 @@
     hoist-non-react-statics "^3.0.1"
     react-native-safe-area-view "^0.14.1"
     react-native-screens "^1.0.0 || ^1.0.0-alpha"
+
+"@react-navigation/native@^5.0.0-alpha.21":
+  version "5.0.0-alpha.21"
+  resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-5.0.0-alpha.21.tgz#346827f68b7667fc51a31eda784213a5f5041297"
+  integrity sha512-bui4ePYd00ElsmrKUAyCEcYZ99dme2NDXkQCJ6gZ5QEU3U+Gp2Q80TIJKegMMA4ypFy57oMQ/Sub4ckMJV0zgg==
+  dependencies:
+    "@react-navigation/core" "^5.0.0-alpha.29"
+
+"@react-navigation/routers@^5.0.0-alpha.18":
+  version "5.0.0-alpha.18"
+  resolved "https://registry.yarnpkg.com/@react-navigation/routers/-/routers-5.0.0-alpha.18.tgz#515ae91c5c4cd0156c505e4de810c3fe996ecd75"
+  integrity sha512-XRbGHD43C2hJ8gCvCfnDNGvk5r4pJd2k8UQUjfKauVRB1UObxnLCvuB1lsXaAL7lxLmHOkkwTXSoCMmrTQnmnw==
+  dependencies:
+    "@react-navigation/core" "^5.0.0-alpha.29"
+    shortid "^2.2.15"
+
+"@react-navigation/stack@^5.0.0-alpha.46":
+  version "5.0.0-alpha.46"
+  resolved "https://registry.yarnpkg.com/@react-navigation/stack/-/stack-5.0.0-alpha.46.tgz#a0a5f5eb757f688ae8ae0354a9d0f5f5c2aaa864"
+  integrity sha512-pZVpZgBlFFE0SIS7nyjzx5ZCIDfhhMW8sUoW/nFtFAbbnuoNUlHRj4mzdFQe400gKOY+S93zvWNLjHQVZUbuaA==
+  dependencies:
+    "@react-navigation/routers" "^5.0.0-alpha.18"
+    color "^3.1.2"
 
 "@types/babel__core@^7.1.0":
   version "7.1.3"
@@ -2607,7 +2640,7 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
-escape-string-regexp@2.0.0:
+escape-string-regexp@2.0.0, escape-string-regexp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
@@ -5224,6 +5257,11 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
+nanoid@^2.1.0:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.8.tgz#2dbb0224231b246e3b4c819de7bfea6384dabf08"
+  integrity sha512-g1z+n5s26w0TGKh7gjn7HCqurNKMZWzH08elXzh/gM/csQHd/UqDV6uxMghQYg9IvqRPm1QpeMk50YMofHvEjQ==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -5916,7 +5954,7 @@ query-string@6.5:
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
 
-query-string@^6.4.2:
+query-string@^6.4.2, query-string@^6.9.0:
   version "6.9.0"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.9.0.tgz#1c3b727c370cf00f177c99f328fda2108f8fa3dd"
   integrity sha512-KG4bhCFYapExLsUHrFt+kQVEegF2agm4cpF/VNc6pZVthIfCc/GK8t8VyNIE3nyXG9DK3Tf2EGkxjR6/uRdYsA==
@@ -6680,6 +6718,13 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
+shortid@^2.2.15:
+  version "2.2.15"
+  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.15.tgz#2b902eaa93a69b11120373cd42a1f1fe4437c122"
+  integrity sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==
+  dependencies:
+    nanoid "^2.1.0"
+
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -7371,6 +7416,13 @@ url-parse@^1.4.4:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
+
+use-subscription@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.3.0.tgz#3df13a798e826c8d462899423293289a3362e4e6"
+  integrity sha512-buZV7FUtnbOr+65dN7PHK7chHhQGfk/yjgqfpRLoWuHIAc4klAD/rdot2FsPNtFthN1ZydvA8tR/mWBMQ+/fDQ==
+  dependencies:
+    object-assign "^4.1.1"
 
 use@^3.1.0:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1165,16 +1165,6 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/masked-view/-/masked-view-0.1.5.tgz#25421be6cd943a4b1660b62cfbcd45be8891462c"
   integrity sha512-Lj1DzfCmW0f4HnmHtEuX8Yy2f7cnUA8r5KGGUuDDGtQt1so6QJkKeUmsnLo2zYDtsF8due6hvIL06Vdo5xxuLQ==
 
-"@react-navigation/core@^3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-3.5.1.tgz#7a2339fca3496979305fb3a8ab88c2ca8d8c214d"
-  integrity sha512-q7NyhWVYOhVIWqL2GZKa6G78YarXaVTTtOlSDkvy4ZIggo40wZzamlnrJRvsaQX46gsgw45FAWb5SriHh8o7eA==
-  dependencies:
-    hoist-non-react-statics "^3.3.0"
-    path-to-regexp "^1.7.0"
-    query-string "^6.4.2"
-    react-is "^16.8.6"
-
 "@react-navigation/core@^5.0.0-alpha.29":
   version "5.0.0-alpha.29"
   resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-5.0.0-alpha.29.tgz#547f3468c2c9fab839e72c76d5582c0396006a29"
@@ -1184,15 +1174,6 @@
     query-string "^6.9.0"
     shortid "^2.2.15"
     use-subscription "^1.3.0"
-
-"@react-navigation/native@^3.6.2":
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-3.6.2.tgz#3634697b6350cc5189657ae4551f2d52b57fbbf0"
-  integrity sha512-Cybeou6N82ZeRmgnGlu+wzlV3z5BZQR2dmYaNFV1TNLUGHqtvv8E7oNw9uYcz9Ox5LFbiX+FdNTn2d6ZPlK0kg==
-  dependencies:
-    hoist-non-react-statics "^3.0.1"
-    react-native-safe-area-view "^0.14.1"
-    react-native-screens "^1.0.0 || ^1.0.0-alpha"
 
 "@react-navigation/native@^5.0.0-alpha.21":
   version "5.0.0-alpha.21"
@@ -3605,7 +3586,7 @@ hoist-non-react-statics@^2.3.1:
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
 
-hoist-non-react-statics@^3.0.1, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#101685d3aff3b23ea213163f6e8e12f4f111e19f"
   integrity sha512-wbg3bpgA/ZqWrZuMOeJi8+SKMhr7X9TesL/rXMjTzh0p0JUBo3II8DHboYbuIXWRlttrUFxwcu/5kygrCw8fJw==
@@ -5954,7 +5935,7 @@ query-string@6.5:
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
 
-query-string@^6.4.2, query-string@^6.9.0:
+query-string@^6.9.0:
   version "6.9.0"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.9.0.tgz#1c3b727c370cf00f177c99f328fda2108f8fa3dd"
   integrity sha512-KG4bhCFYapExLsUHrFt+kQVEegF2agm4cpF/VNc6pZVthIfCc/GK8t8VyNIE3nyXG9DK3Tf2EGkxjR6/uRdYsA==
@@ -5986,7 +5967,7 @@ react-devtools-core@^3.6.3:
     shell-quote "^1.6.1"
     ws "^3.3.1"
 
-react-is@^16.5.2, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.2, react-is@^16.8.4, react-is@^16.8.6:
+react-is@^16.5.2, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.2, react-is@^16.8.4:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
@@ -6016,24 +5997,10 @@ react-native-safe-area-context@0.6.0:
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-0.6.0.tgz#f53f5a5bcafb462a8798a26b145e68946389ad60"
   integrity sha512-blY0akr3ZLTuZFdUotmjV+7LVXpBnd5CGFlNhTiarNNGJoHu79K42IJpUpmtg75iC9aWbSW7QHstlP0xz11V0A==
 
-react-native-safe-area-view@^0.14.1:
-  version "0.14.8"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-view/-/react-native-safe-area-view-0.14.8.tgz#ef33c46ff8164ae77acad48c3039ec9c34873e5b"
-  integrity sha512-MtRSIcZNstxv87Jet+UsPhEd1tpGe8cVskDXlP657x6rHpSrbrc+y13ZNXrwAgGNNhqQNX7UJT68ZIq//ZRmvw==
-  dependencies:
-    hoist-non-react-statics "^2.3.1"
-
 react-native-screens@2.0.0-alpha.12:
   version "2.0.0-alpha.12"
   resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.0.0-alpha.12.tgz#35a6ef3b472958e9d35f0ca9e582d0d158f8e379"
   integrity sha512-x9M7FEdcm97bVDp3pi//nhduJHLFMrmDQs0fq299yx3kHdgHbrmhsa8jgW4HvDQhjyPE0FWADY/GrXFuPRj80w==
-  dependencies:
-    debounce "^1.2.0"
-
-"react-native-screens@^1.0.0 || ^1.0.0-alpha":
-  version "1.0.0-alpha.23"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-1.0.0-alpha.23.tgz#25d7ea4d11bda4fcde2d1da7ae50271c6aa636e0"
-  integrity sha512-tOxHGQUN83MTmQB4ghoQkibqOdGiX4JQEmeyEv96MKWO/x8T2PJv84ECUos9hD3blPRQwVwSpAid1PPPhrVEaw==
   dependencies:
     debounce "^1.2.0"
 
@@ -6083,21 +6050,6 @@ react-native-webview@7.4.3:
     scheduler "0.15.0"
     stacktrace-parser "^0.1.3"
     whatwg-fetch "^3.0.0"
-
-react-navigation-stack@^2.0.0-alpha.42:
-  version "2.0.0-alpha.42"
-  resolved "https://registry.yarnpkg.com/react-navigation-stack/-/react-navigation-stack-2.0.0-alpha.42.tgz#4010ca05f106b7fc9dcb77d8e37e4bce93206081"
-  integrity sha512-Pva+yUK6zPg2PDywr7X/fZiOK4YUiumdm5r1tilbr5G49ezHmEjYL3+gvnrOqAzutciuIn//EJCxRLUhf6l7bg==
-  dependencies:
-    color "^3.1.2"
-
-react-navigation@^4.0.10:
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/react-navigation/-/react-navigation-4.0.10.tgz#ddf41134600689d6ba99e35dd22ba1f664f91e5c"
-  integrity sha512-7PqvmsdQ7HIyxPUMYbd9Uq//VoMdniEOLAOSvIhb/ExtbAt/1INSjUF+RiMWOMCWLTCNvNPRvTz7xy7qwWureg==
-  dependencies:
-    "@react-navigation/core" "^3.5.1"
-    "@react-navigation/native" "^3.6.2"
 
 react-proxy@^1.1.7:
   version "1.1.8"


### PR DESCRIPTION
Upgrades to React Navigation v5, which changes the way that navigators are configured, and is a lot nicer (IMO).

I made the choice to move static titles/etc up into the Routes components, but we could keep those in static props if we want; https://reactnavigation.org/docs/en/next/upgrading-from-4.x.html#configuring-the-navigator has some discussion on this.

Our header buttons are now configured as part of the screen's lifecycle instead, which is mucho cleaner.

Nav state is no longer stored in Redux at all, per https://reactnavigation.org/docs/en/next/upgrading-from-4.x.html#navigation-state-in-redux - apparently you can inspect via Redux dev tools instead, although I couldn't try this, as the dev tools are broken for me entirely.