### PR TITLE
Fix text alignment

### DIFF
--- a/components/Posts/Form.js
+++ b/components/Posts/Form.js
@@ -79,7 +79,7 @@ export default class Form extends Component {
 			<ScrollView>
 				<View style={ styles.contentField }>
 					<TextInput
-						autoFocus
+						autoFocus={ ! object.title }
 						placeholder="Enter title…"
 						style={ styles.title }
 						value={ object.title ? object.title.raw : null }

--- a/components/Posts/Form.js
+++ b/components/Posts/Form.js
@@ -17,7 +17,6 @@ const styles = StyleSheet.create( {
 	title: {
 		color: '#666666',
 		fontSize: 20,
-		lineHeight: 36,
 		height: 36,
 	},
 	list: {


### PR DESCRIPTION
Fixes the alignment in the title field. Turns out the lineHeight attribute only affects the placeholder, not the input (or something)